### PR TITLE
Use lazy eval for params that default to attributes

### DIFF
--- a/resources/git_credentials.rb
+++ b/resources/git_credentials.rb
@@ -2,8 +2,8 @@ resource_name :git_credentials
 
 property :path,  String, default: lazy { |r| Dir.home(r.owner) + '/.git-credentials' }
 property :owner, String, name_property: true
-property :secrets_databag, String, default: node['osl-git']['secrets_databag']
-property :secrets_item,    String, default: node['osl-git']['secrets_item']
+property :secrets_databag, String, default: lazy { node['osl-git']['secrets_databag'] }
+property :secrets_item,    String, default: lazy { node['osl-git']['secrets_item'] }
 property :use_http_path, [TrueClass, FalseClass], default: true
 
 default_action :create

--- a/spec/git_credentials_spec.rb
+++ b/spec/git_credentials_spec.rb
@@ -1,0 +1,175 @@
+require_relative 'spec_helper'
+
+describe 'osl-git-test::chefspec_git_credentials' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p.merge(step_into: 'git_credentials')).converge(described_recipe)
+      end
+      before do
+        allow(Dir).to receive(:home).and_call_original
+        allow(Dir).to receive(:home).with('foo').and_return('/home/foo')
+        allow(Dir).to receive(:home).with('root').and_return('/root')
+        stub_data_bag('databag').and_return(%w(item item2))
+        stub_data_bag_item('databag', 'item').and_return(credentials: %w(foo bar))
+        stub_data_bag_item('databag', 'item2').and_return(credentials: %w(hello world))
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run).to create_git_credentials('root').with(
+          path: '/root/.git-credentials',
+          owner: 'root',
+          secrets_databag: 'databag',
+          secrets_item: 'item',
+          use_http_path: true
+        )
+      end
+      it do
+        expect(chef_run).to set_git_config('credential.useHttpPath').with(
+          value: 'true',
+          scope: 'global',
+          user: 'root'
+        )
+      end
+      it do
+        expect(chef_run).to set_git_config('credential.helper').with(
+          value: 'store --file /root/.git-credentials',
+          scope: 'global',
+          user: 'root'
+        )
+      end
+      it do
+        expect(chef_run).to create_template('/root/.git-credentials').with(
+          cookbook: 'osl-git',
+          source: 'git-credentials.erb',
+          sensitive: true,
+          owner: 'root',
+          variables: { credentials: %w(foo bar) }
+        )
+      end
+      it do
+        expect(chef_run).to render_file('/root/.git-credentials').with_content(/^foo$\n^bar$/)
+      end
+      context 'useHttpPath disabled' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p.merge(step_into: 'git_credentials')) do |node|
+            node.normal['osl-git-test']['use_http_path'] = false
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to create_git_credentials('root').with(
+            path: '/root/.git-credentials',
+            owner: 'root',
+            secrets_databag: 'databag',
+            secrets_item: 'item',
+            use_http_path: false
+          )
+        end
+        it do
+          expect(chef_run).to set_git_config('credential.useHttpPath').with(
+            value: 'false',
+            scope: 'global',
+            user: 'root'
+          )
+        end
+      end
+      context 'different owner' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p.merge(step_into: 'git_credentials')) do |node|
+            node.normal['osl-git-test']['owner'] = 'foo'
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to create_git_credentials('foo').with(
+            path: '/home/foo/.git-credentials',
+            owner: 'foo',
+            secrets_databag: 'databag',
+            secrets_item: 'item',
+            use_http_path: true
+          )
+        end
+        it do
+          expect(chef_run).to set_git_config('credential.useHttpPath').with(
+            value: 'true',
+            scope: 'global',
+            user: 'foo'
+          )
+        end
+        it do
+          expect(chef_run).to set_git_config('credential.helper').with(
+            value: 'store --file /home/foo/.git-credentials',
+            scope: 'global',
+            user: 'foo'
+          )
+        end
+        it do
+          expect(chef_run).to create_template('/home/foo/.git-credentials').with(
+            cookbook: 'osl-git',
+            source: 'git-credentials.erb',
+            sensitive: true,
+            owner: 'foo',
+            variables: { credentials: %w(foo bar) }
+          )
+        end
+        it do
+          expect(chef_run).to render_file('/home/foo/.git-credentials').with_content(/^foo$\n^bar$/)
+        end
+      end
+      context 'different databag item' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p.merge(step_into: 'git_credentials')) do |node|
+            node.normal['osl-git-test']['secrets_item'] = 'item2'
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to create_git_credentials('root').with(
+            path: '/root/.git-credentials',
+            owner: 'root',
+            secrets_databag: 'databag',
+            secrets_item: 'item2',
+            use_http_path: true
+          )
+        end
+        it do
+          expect(chef_run).to create_template('/root/.git-credentials').with(
+            cookbook: 'osl-git',
+            source: 'git-credentials.erb',
+            sensitive: true,
+            owner: 'root',
+            variables: { credentials: %w(hello world) }
+          )
+        end
+        it do
+          expect(chef_run).to render_file('/root/.git-credentials').with_content(/^hello$\n^world$/)
+        end
+      end
+      context 'delete action' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p.merge(step_into: 'git_credentials')) do |node|
+            node.normal['osl-git-test']['action'] = :delete
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to delete_git_credentials('root').with(
+            path: '/root/.git-credentials',
+            owner: 'root',
+            secrets_databag: 'databag',
+            secrets_item: 'item',
+            use_http_path: true
+          )
+        end
+        it do
+          expect(chef_run).to run_execute('git config --global --unset-all credential.helper').with(
+            user: 'root',
+            environment: { 'HOME' => '/root' }
+          )
+        end
+        it do
+          expect(chef_run).to delete_file('/root/.git-credentials')
+        end
+      end
+    end
+  end
+end

--- a/test/cookbooks/osl-git-test/metadata.rb
+++ b/test/cookbooks/osl-git-test/metadata.rb
@@ -9,4 +9,6 @@ description      'Installs/Configures osl-git-test'
 long_description 'Installs/Configures osl-git-test'
 version          '0.1.0'
 
+depends          'osl-git'
+
 supports         'centos', '~> 7.0'

--- a/test/cookbooks/osl-git-test/recipes/chefspec_git_credentials.rb
+++ b/test/cookbooks/osl-git-test/recipes/chefspec_git_credentials.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook:: osl-git-test
+# Recipe:: chefspec_git_credentials
+#
+# Copyright:: 2018, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This recipe creates a git_credentials resource for testing in ChefSpec.
+# Attributes allow changing values for different test contexts.
+
+node.default['osl-git-test']['action'] = :create
+node.default['osl-git-test']['owner'] = 'root'
+node.default['osl-git-test']['secrets_item'] = 'item'
+node.default['osl-git-test']['use_http_path'] = true
+
+git_credentials node['osl-git-test']['owner'] do
+  use_http_path node['osl-git-test']['use_http_path']
+  secrets_item node['osl-git-test']['secrets_item']
+  action node['osl-git-test']['action']
+end


### PR DESCRIPTION
This evaluates the attributes at run-time so the default values for
databag_secrets and databag_items actually reflect how the attributes
are set.

We were running into some problems with setting the databag items via `osl-git` attributes in `proj-lf::bugs`, and originally suspected that this was an issue with attribute precedence. However, based on testing this it seems the real problem was a lack of lazy evaluation on the attributes.