### PR TITLE
removed suspect whitespace trimmer tag

### DIFF
--- a/templates/default/git-credentials.erb
+++ b/templates/default/git-credentials.erb
@@ -2,4 +2,4 @@
 
 <% @credentials.each do |credential| %>
 <%= credential %>
-<% end -%>
+<% end %>


### PR DESCRIPTION
lf-web1 isn't pull the credentials for a11yweb for some reason, even though running 
`knife data bag show linux_foundation web1-git-credentials` shows that the token exists there. The credentials for patentcommons is above the comment somehow, might be a bug with chef's templating?


This probably isn't the problem, but what if it is? Plus its clearer what this does, because the `-` isn't necessary.