### PR TITLE
Add group parameter to git_credential resource

### DIFF
--- a/spec/git_credentials_spec.rb
+++ b/spec/git_credentials_spec.rb
@@ -21,6 +21,7 @@ describe 'osl-git-test::chefspec_git_credentials' do
         expect(chef_run).to create_git_credentials('root').with(
           path: '/root/.git-credentials',
           owner: 'root',
+          group: 'root',
           secrets_databag: 'databag',
           secrets_item: 'item',
           use_http_path: true
@@ -30,14 +31,16 @@ describe 'osl-git-test::chefspec_git_credentials' do
         expect(chef_run).to set_git_config('credential.useHttpPath').with(
           value: 'true',
           scope: 'global',
-          user: 'root'
+          user: 'root',
+          group: 'root'
         )
       end
       it do
         expect(chef_run).to set_git_config('credential.helper').with(
           value: 'store --file /root/.git-credentials',
           scope: 'global',
-          user: 'root'
+          user: 'root',
+          group: 'root'
         )
       end
       it do
@@ -46,6 +49,7 @@ describe 'osl-git-test::chefspec_git_credentials' do
           source: 'git-credentials.erb',
           sensitive: true,
           owner: 'root',
+          group: 'root',
           variables: { credentials: %w(foo bar) }
         )
       end
@@ -62,6 +66,7 @@ describe 'osl-git-test::chefspec_git_credentials' do
           expect(chef_run).to create_git_credentials('root').with(
             path: '/root/.git-credentials',
             owner: 'root',
+            group: 'root',
             secrets_databag: 'databag',
             secrets_item: 'item',
             use_http_path: false
@@ -71,7 +76,8 @@ describe 'osl-git-test::chefspec_git_credentials' do
           expect(chef_run).to set_git_config('credential.useHttpPath').with(
             value: 'false',
             scope: 'global',
-            user: 'root'
+            user: 'root',
+            group: 'root'
           )
         end
       end
@@ -79,12 +85,14 @@ describe 'osl-git-test::chefspec_git_credentials' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p.merge(step_into: 'git_credentials')) do |node|
             node.normal['osl-git-test']['owner'] = 'foo'
+            node.normal['osl-git-test']['group'] = 'foo'
           end.converge(described_recipe)
         end
         it do
           expect(chef_run).to create_git_credentials('foo').with(
             path: '/home/foo/.git-credentials',
             owner: 'foo',
+            group: 'foo',
             secrets_databag: 'databag',
             secrets_item: 'item',
             use_http_path: true
@@ -94,14 +102,16 @@ describe 'osl-git-test::chefspec_git_credentials' do
           expect(chef_run).to set_git_config('credential.useHttpPath').with(
             value: 'true',
             scope: 'global',
-            user: 'foo'
+            user: 'foo',
+            group: 'foo'
           )
         end
         it do
           expect(chef_run).to set_git_config('credential.helper').with(
             value: 'store --file /home/foo/.git-credentials',
             scope: 'global',
-            user: 'foo'
+            user: 'foo',
+            group: 'foo'
           )
         end
         it do
@@ -110,6 +120,7 @@ describe 'osl-git-test::chefspec_git_credentials' do
             source: 'git-credentials.erb',
             sensitive: true,
             owner: 'foo',
+            group: 'foo',
             variables: { credentials: %w(foo bar) }
           )
         end
@@ -127,6 +138,7 @@ describe 'osl-git-test::chefspec_git_credentials' do
           expect(chef_run).to create_git_credentials('root').with(
             path: '/root/.git-credentials',
             owner: 'root',
+            group: 'root',
             secrets_databag: 'databag',
             secrets_item: 'item2',
             use_http_path: true
@@ -138,6 +150,8 @@ describe 'osl-git-test::chefspec_git_credentials' do
             source: 'git-credentials.erb',
             sensitive: true,
             owner: 'root',
+            group: 'root',
+            secrets_databag: 'databag',
             variables: { credentials: %w(hello world) }
           )
         end
@@ -155,6 +169,7 @@ describe 'osl-git-test::chefspec_git_credentials' do
           expect(chef_run).to delete_git_credentials('root').with(
             path: '/root/.git-credentials',
             owner: 'root',
+            group: 'root',
             secrets_databag: 'databag',
             secrets_item: 'item',
             use_http_path: true
@@ -163,6 +178,8 @@ describe 'osl-git-test::chefspec_git_credentials' do
         it do
           expect(chef_run).to run_execute('git config --global --unset-all credential.helper').with(
             user: 'root',
+            group: 'root',
+            secrets_databag: 'databag',
             environment: { 'HOME' => '/root' }
           )
         end

--- a/test/cookbooks/osl-git-test/recipes/attributes.rb
+++ b/test/cookbooks/osl-git-test/recipes/attributes.rb
@@ -27,34 +27,45 @@ git '/root/test' do
 end
 
 # Testing non-default properties
+group 'foo'
+
 user 'foo' do
+  group 'foo'
   manage_home true
 end
 
 git_credentials 'foo' do
+  group 'foo'
   use_http_path false
 end
 
 git '/home/foo/test' do
   user 'foo'
+  group 'foo'
   repository 'https://git.osuosl.org/osuosl/test.git'
 end
 
 # Testing :delete action
+group 'bar'
+
 user 'bar' do
+  group 'bar'
   manage_home true
 end
 
 file '/home/bar/.git-credentials' do
   owner 'bar'
+  group 'bar'
 end
 
 file '/home/bar/.gitconfig' do
   owner 'bar'
+  group 'bar'
   content '[credential]
         helper = store --file /home/foo/.git-credentials'
 end
 
 git_credentials 'bar' do
+  group 'bar'
   action :delete
 end

--- a/test/cookbooks/osl-git-test/recipes/chefspec_git_credentials.rb
+++ b/test/cookbooks/osl-git-test/recipes/chefspec_git_credentials.rb
@@ -21,11 +21,13 @@
 
 node.default['osl-git-test']['action'] = :create
 node.default['osl-git-test']['owner'] = 'root'
+node.default['osl-git-test']['group'] = 'root'
 node.default['osl-git-test']['secrets_item'] = 'item'
 node.default['osl-git-test']['use_http_path'] = true
 
 git_credentials node['osl-git-test']['owner'] do
   use_http_path node['osl-git-test']['use_http_path']
   secrets_item node['osl-git-test']['secrets_item']
+  group node['osl-git-test']['group']
   action node['osl-git-test']['action']
 end

--- a/test/cookbooks/osl-git-test/recipes/databag.rb
+++ b/test/cookbooks/osl-git-test/recipes/databag.rb
@@ -30,35 +30,46 @@ git '/root/test' do
 end
 
 # Testing non-default properties
+group 'foo'
+
 user 'foo' do
+  group 'foo'
   manage_home true
 end
 
 git_credentials 'foo' do
+  group 'foo'
   use_http_path false
   secrets_item 'item2'
 end
 
 git '/home/foo/test' do
   user 'foo'
+  group 'foo'
   repository 'https://git.osuosl.org/osuosl/test.git'
 end
 
 # Testing :delete action
+group 'bar'
+
 user 'bar' do
+  group 'bar'
   manage_home true
 end
 
 file '/home/bar/.git-credentials' do
   owner 'bar'
+  group 'bar'
 end
 
 file '/home/bar/.gitconfig' do
   owner 'bar'
+  group 'bar'
   content '[credential]
         helper = store --file /home/foo/.git-credentials'
 end
 
 git_credentials 'bar' do
+  group 'bar'
   action :delete
 end

--- a/test/integration/git-credentials-attributes/serverspec/git_credentials_attributes_spec.rb
+++ b/test/integration/git-credentials-attributes/serverspec/git_credentials_attributes_spec.rb
@@ -9,6 +9,7 @@ end
 describe file '/root/.git-credentials' do
   it { should be_file }
   it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
   it { should be_mode '600' }
   [
     %r{https://user:pass@example.net/hello/world.git},
@@ -21,6 +22,7 @@ end
 describe file '/root/.gitconfig' do
   it { should be_file }
   it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
   its(:content) { should match %r{helper = store --file /root/\.git-credentials} }
   its(:content) { should match(/useHttpPath = true/) }
 end
@@ -32,6 +34,7 @@ end
 describe file '/home/foo/.git-credentials' do
   it { should be_file }
   it { should be_owned_by 'foo' }
+  it { should be_grouped_into 'foo' }
   it { should be_mode '600' }
   [
     %r{https://user:pass@example.net/hello/world.git},
@@ -44,6 +47,7 @@ end
 describe file '/home/foo/.gitconfig' do
   it { should be_file }
   it { should be_owned_by 'foo' }
+  it { should be_grouped_into 'foo' }
   its(:content) { should match %r{helper = store --file /home/foo/\.git-credentials} }
   its(:content) { should match(/useHttpPath = false/) }
 end
@@ -55,6 +59,7 @@ end
 describe file '/home/bar/.gitconfig' do
   it { should be_file }
   it { should be_owned_by 'bar' }
+  it { should be_grouped_into 'bar' }
   its(:content) { should_not match(/helper/) }
   its(:content) { should_not match(/useHttpPath/) }
 end


### PR DESCRIPTION
This allows us to set how the various files are group owned instead of
defaulting to root. For now keep the default as root which is currently what
happens. But now it's at least configurable.