### PR TITLE
Update ChefSpec platform version

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,23 +5,11 @@ ChefSpec::Coverage.start! { add_filter 'osl-git' }
 
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.2.1511',
-}.freeze
-
-CENTOS_6 = {
-  platform: 'centos',
-  version: '6.8',
-}.freeze
-
-DEBIAN_8 = {
-  platform: 'debian',
-  version: '8.8',
+  version: '7.4.1708',
 }.freeze
 
 ALL_PLATFORMS = [
-  CENTOS_6,
   CENTOS_7,
-  DEBIAN_8,
 ].freeze
 
 RSpec.configure do |config|


### PR DESCRIPTION
I removed `CENTOS_6` and `DEBIAN_8` because these platforms are not listed as supported in `metadata.rb`.