### PR TITLE
Chef 14 compatibility fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,11 +11,5 @@ Style/NumericLiteralPrefix:
 Metrics/LineLength:
   Max: 120
 
-Style/IfUnlessModifier:
-  MaxLineLength: 120
-
-Style/WhileUntilModifier:
-  MaxLineLength: 120
-
 Metrics/BlockLength:
   Enabled: false

--- a/spec/git_credentials_spec.rb
+++ b/spec/git_credentials_spec.rb
@@ -151,7 +151,6 @@ describe 'osl-git-test::chefspec_git_credentials' do
             sensitive: true,
             owner: 'root',
             group: 'root',
-            secrets_databag: 'databag',
             variables: { credentials: %w(hello world) }
           )
         end
@@ -179,7 +178,6 @@ describe 'osl-git-test::chefspec_git_credentials' do
           expect(chef_run).to run_execute('git config --global --unset-all credential.helper').with(
             user: 'root',
             group: 'root',
-            secrets_databag: 'databag',
             environment: { 'HOME' => '/root' }
           )
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,9 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-ChefSpec::Coverage.start! { add_filter 'osl-git' }
-
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.4.1708',
+  version: '7',
 }.freeze
 
 ALL_PLATFORMS = [
@@ -13,5 +11,5 @@ ALL_PLATFORMS = [
 ].freeze
 
 RSpec.configure do |config|
-  config.log_level = :fatal
+  config.log_level = :warn
 end


### PR DESCRIPTION
**Old ChefDK (before)**
- [x] Ensure all ChefSpec tests pass
- [x] Ensure all Inspec tests pass

**New ChefDK**
- [x] Ensure cookstyle is passing
- [x] Apply foodcritic fixes
- [x] Ensure `rake` passes
- [x] Ensure all Inspec tests pass

**Old ChefDK (after)**
- [x] Repeat all tests above using old ChefDK