### PR TITLE
Remove comment from git credential template

### DIFF
--- a/templates/default/git-credentials.erb
+++ b/templates/default/git-credentials.erb
@@ -1,5 +1,3 @@
-# This file is managed by Chef, any manual edits will be overwritten
-
 <% @credentials.each do |credential| %>
 <%= credential %>
 <% end -%>

--- a/test/integration/data_bags/osl-git/item1.json
+++ b/test/integration/data_bags/osl-git/item1.json
@@ -2,7 +2,7 @@
   "id": "item1",
   "credentials": [
     "https://name:token@example.123/hello/world.git",
-    "bar:foo@example.xyz/foo/bar.git",
+    "https://bar:foo@example.xyz/foo/bar.git",
     "https://gitlab+deploy-token-13:CWN8Fsjrtare7yAHkknj@git.osuosl.org/osuosl/test.git"
   ]
 }

--- a/test/integration/data_bags/osl-git/item2.json
+++ b/test/integration/data_bags/osl-git/item2.json
@@ -2,7 +2,7 @@
   "id": "item2",
   "credentials": [
     "https://username:secret@example.456",
-    "foobar:barfoo@example.abc",
+    "https://foobar:barfoo@example.abc",
     "https://gitlab+deploy-token-13:CWN8Fsjrtare7yAHkknj@git.osuosl.org"
   ]
 }

--- a/test/integration/git-credentials-databag/inspec/git_credentials_databag_spec.rb
+++ b/test/integration/git-credentials-databag/inspec/git_credentials_databag_spec.rb
@@ -8,7 +8,7 @@ describe file '/root/.git-credentials' do
   its('mode') { should cmp '0600' }
   [
     %r{https://name:token@example.123/hello/world.git},
-    %r{bar:foo@example.xyz/foo/bar.git},
+    %r{https://bar:foo@example.xyz/foo/bar.git},
   ].each do |line|
     its('content') { should match line }
   end


### PR DESCRIPTION
This is causing issues with newer versions of git with an error such as the
following:

```
warning: url has no scheme: # This file is managed by Chef, any manual edits will be overwritten
fatal: credential url cannot be parsed: # This file is managed by Chef, any manual edits will be overwritten
fatal: could not read Username
```