### PR TITLE
Ensure git lfs is properly installed in a repo

### DIFF
--- a/spec/osl_gitlfs_spec.rb
+++ b/spec/osl_gitlfs_spec.rb
@@ -54,11 +54,63 @@ describe 'osl-git-test::osl_gitlfs' do
         expect(chef_run.git('/tmp/bar')).to notify('execute[git lfs pull /tmp/bar]').to(:run)
       end
       it do
+        expect(chef_run).to run_execute('git lfs install /foo').with(
+          user: 'root',
+          group: 'root',
+          login: true,
+          cwd: '/foo',
+          command: 'git lfs install'
+        )
+      end
+      it do
+        expect(chef_run).to run_execute('git lfs install /tmp/bar').with(
+          user: 'nobody',
+          group: 'nobody',
+          login: true,
+          cwd: '/tmp/bar',
+          command: 'git lfs install'
+        )
+      end
+      context 'git lfs already installed' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p.merge(step_into: 'osl_gitlfs')).converge(described_recipe)
+        end
+
+        before do
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with('/foo/.git/hooks/pre-push').and_return(true)
+          allow(File).to receive(:exist?).with('/tmp/bar/.git/hooks/pre-push').and_return(true)
+          allow(File).to receive(:readlines).and_call_original
+          allow(File).to receive(:readlines).with('/foo/.git/hooks/pre-push').and_return(%w(git-lfs))
+          allow(File).to receive(:readlines).with('/tmp/bar/.git/hooks/pre-push').and_return(%w(git-lfs))
+        end
+
+        it do
+          expect(chef_run).to_not run_execute('git lfs install /foo').with(
+            user: 'root',
+            group: 'root',
+            login: true,
+            cwd: '/foo',
+            command: 'git lfs install'
+          )
+        end
+        it do
+          expect(chef_run).to_not run_execute('git lfs install /tmp/bar').with(
+            user: 'nobody',
+            group: 'nobody',
+            login: true,
+            cwd: '/tmp/bar',
+            command: 'git lfs install'
+          )
+        end
+      end
+      it do
         expect(chef_run).to nothing_execute('git lfs pull /foo').with(
           user: 'root',
           group: 'root',
           login: true,
-          cwd: '/foo'
+          cwd: '/foo',
+          command: 'git lfs pull'
         )
       end
       it do
@@ -66,7 +118,8 @@ describe 'osl-git-test::osl_gitlfs' do
           user: 'nobody',
           group: 'nobody',
           login: true,
-          cwd: '/tmp/bar'
+          cwd: '/tmp/bar',
+          command: 'git lfs pull'
         )
       end
     end

--- a/test/integration/osl-gitlfs/inspec/osl_gitlfs_spec.rb
+++ b/test/integration/osl-gitlfs/inspec/osl_gitlfs_spec.rb
@@ -16,6 +16,13 @@ describe directory('/tmp/bar/.git') do
   its('group') { should eq 'nobody' }
 end
 
+describe file('/tmp/bar/.git/hooks/pre-push') do
+  it { should be_executable }
+  its('owner') { should eq 'nobody' }
+  its('group') { should eq 'nobody' }
+  its('content') { should match /git-lfs/ }
+end
+
 describe file('/foo/osllogo.png') do
   it { should exist }
   its('size') { should eq 13011 }


### PR DESCRIPTION
We've run into a problem where we needed to manually run `git lfs install` inside of repositories [1]. To work around this properly, let's add this to the resource.

[1] https://support.osuosl.org/Ticket/Display.html?id=32316

Signed-off-by: Lance Albertson <lance@osuosl.org>
