### PR TITLE
Migrate base::gitlfs to this cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,9 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
-cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
-cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
+cookbook 'osl-resources', git: 'git@github.com:osuosl-cookbooks/osl-resources', branch: 'main'
 cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
+
+# Test dependencies
 cookbook 'osl-git-test', path: 'test/cookbooks/osl-git-test'
 
 metadata

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,6 +19,9 @@ suites:
       - recipe[osl-git::ius]
     excludes:
       - centos_stream-8
+  - name: gitlfs
+    run_list:
+      - recipe[osl-git::gitlfs]
   - name: osl-gitlfs
     run_list:
       - recipe[osl-git-test::osl_gitlfs]

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,8 @@ source_url       'https://github.com/osuosl-cookbooks/osl-git'
 description      'Installs/Configures osl-git'
 version          '1.9.1'
 
-depends          'base'
 depends          'git'
+depends          'osl-resources'
 depends          'osl-selinux'
 depends          'yum-ius', '~> 3.1.0'
 

--- a/recipes/gitlfs.rb
+++ b/recipes/gitlfs.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook:: osl-git
-# Recipe:: default
+# Recipe:: gitlfs
 #
-# Copyright:: 2018-2022, Oregon State University
+# Copyright:: 2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+osl_packagecloud_repo 'github/git-lfs' do
+  only_if { %w(x86_64).include?(node['kernel']['machine']) }
+end
 
-include_recipe 'osl-selinux'
-include_recipe 'git'
-include_recipe 'osl-git::gitlfs'
+yum_repository 'git-lfs' do
+  description "OSL git-lfs #{node['kernel']['machine']} repo"
+  gpgkey 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+  gpgcheck true
+  baseurl 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/git-lfs/$basearch'
+  only_if { %w(ppc64le s390x aarch64).include?(node['kernel']['machine']) }
+end
+
+package 'git-lfs'

--- a/spec/osl_gitlfs_spec.rb
+++ b/spec/osl_gitlfs_spec.rb
@@ -28,10 +28,7 @@ describe 'osl-git-test::osl_gitlfs' do
         )
       end
       it do
-        expect(chef_run).to include_recipe('base::gitlfs')
-      end
-      it do
-        expect(chef_run).to include_recipe('git')
+        expect(chef_run).to include_recipe('osl-git')
       end
       it do
         expect(chef_run).to sync_git('/foo').with(

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -15,6 +15,9 @@ describe 'osl-git::default' do
       it do
         expect(chef_run).to include_recipe 'git'
       end
+      it do
+        expect(chef_run).to include_recipe 'osl-git::gitlfs'
+      end
     end
   end
 end

--- a/spec/unit/recipes/gitlfs_spec.rb
+++ b/spec/unit/recipes/gitlfs_spec.rb
@@ -1,0 +1,98 @@
+#
+# Cookbook:: osl-git
+# Spec:: gitlfs
+#
+# Copyright:: 2022, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../../spec_helper'
+
+describe 'osl-git::gitlfs' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run).to add_osl_packagecloud_repo('github/git-lfs')
+      end
+      it do
+        expect(chef_run).to_not create_yum_repository('git-lfs')
+      end
+      it do
+        expect(chef_run).to install_package('git-lfs')
+      end
+      context 'setting arch to aarch64' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.automatic['kernel']['machine'] = 'aarch64'
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to_not add_osl_packagecloud_repo('github/git-lfs')
+        end
+        it do
+          expect(chef_run).to create_yum_repository('git-lfs')
+            .with(
+              description: 'OSL git-lfs aarch64 repo',
+              gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+              gpgcheck: true,
+              baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/git-lfs/$basearch'
+            )
+        end
+      end
+      context 'setting arch to ppc64le' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.automatic['kernel']['machine'] = 'ppc64le'
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to create_yum_repository('git-lfs')
+            .with(
+              description: 'OSL git-lfs ppc64le repo',
+              gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+              gpgcheck: true,
+              baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/git-lfs/$basearch'
+            )
+        end
+        it do
+          expect(chef_run).to_not add_osl_packagecloud_repo('github/git-lfs')
+        end
+      end
+      context 'setting arch to s390x' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.automatic['kernel']['machine'] = 's390x'
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to create_yum_repository('git-lfs')
+            .with(
+              description: 'OSL git-lfs s390x repo',
+              gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+              gpgcheck: true,
+              baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/git-lfs/$basearch'
+            )
+        end
+        it do
+          expect(chef_run).to_not add_osl_packagecloud_repo('github/git-lfs')
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gitlfs/controls/gitlfs_control.rb
+++ b/test/integration/gitlfs/controls/gitlfs_control.rb
@@ -1,0 +1,11 @@
+control 'gitlfs' do
+  title 'Verify git-lfs is installed'
+
+  describe package('git-lfs') do
+    it { should be_installed }
+  end
+
+  describe command('git lfs env') do
+    its('stdout') { should match %r{git-lfs/[0-9]+.[0-9]+.[0-9]+} }
+  end
+end

--- a/test/integration/gitlfs/inspec.yml
+++ b/test/integration/gitlfs/inspec.yml
@@ -1,0 +1,2 @@
+---
+name: gitlfs


### PR DESCRIPTION
This will reduce the need for other cookbooks to directly depend on the base cookbook.

In addition, remove the base requirement (and its dependencies) for this cookbook.

Signed-off-by: Lance Albertson <lance@osuosl.org>
