### PR TITLE
Pin git cookbook to 12.x and switch to cinc_infra

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,8 @@ verifier:
   name: inspec
 
 provisioner:
-  name: chef_infra
+  name: cinc_infra
+  product_version: 18
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -6,7 +6,7 @@ module OslGit
           databag,
           item
         )
-      rescue Net::HTTPServerException => e
+      rescue Net::HTTPClientException => e
         databag_item = "#{databag}:#{item}"
         if e.response.code == '404'
           Chef::Log.warn("Could not find databag '#{databag_item}'; falling back to default attributes.")

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ source_url       'https://github.com/osuosl-cookbooks/osl-git'
 description      'Installs/Configures osl-git'
 version          '1.13.4'
 
-depends          'git'
+depends          'git', '~> 12.0'
 depends          'line'
 depends          'osl-resources'
 depends          'osl-selinux'

--- a/resources/git_credentials.rb
+++ b/resources/git_credentials.rb
@@ -35,7 +35,7 @@ action :create do
       owner new_resource.owner
       group new_resource.group
       sensitive true
-      line cred.gsub(/\+/, '%2b')
+      line cred.gsub('+', '%2b')
     end
   end
 end


### PR DESCRIPTION
Pin git cookbook to ~> 12.0 to avoid breakage from the recent major
version release. A proper fix will follow later. Also switch kitchen
provisioner to cinc_infra and apply cookstyle fixes.

Signed-off-by: Lance Albertson <lance@osuosl.org>
